### PR TITLE
Add another equals sign to package versions installed by pip in github actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs=1.3.0 mkdocs-bootswatch=1.1
+      - run: pip install mkdocs==1.3.0 mkdocs-bootswatch==1.1
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Small PR to add a second `=` to pip installation of mkdocs in the github actions workflow. conda only takes one equals sign while pip takes two, and I forgot the second one in the pip installs.