### PR TITLE
Fix the URL in the copyright declaration of the `mkdocs.yml` file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ repo_name: arcadia-computational-training
 repo_url: https://github.com/arcadia-science/arcadia-computational-training
 edit_uri: ""
 
-copyright: 'Copyright &copy; 2022 <a href="https://www.arcadiascience.com">Arcadia Science</a>'
+copyright: 'Copyright &copy; 2022 <a href="https://www.arcadia.science">Arcadia Science</a>'
 
 # change directory names here to reflect directories in the repository
 docs_dir: docs


### PR DESCRIPTION
I felt like @mertcelebi had already caught and fixed this, but somehow it's still in main. Updating to the correct Arcadia Science url https://www.arcadia.science/