### PR TITLE
Fix formatting in first shell AUG lesson 20220906

### DIFF
--- a/docs/arcadia-users-group/20220906-intro-to-shell1/lesson.md
+++ b/docs/arcadia-users-group/20220906-intro-to-shell1/lesson.md
@@ -41,23 +41,25 @@ Click the Terminal button to launch a Terminal that we will work with for the re
 <details>
   <summary>More information on binder and what happens when you click the launch binder button.</summary>
 
-binder is a service that turns a Git repo into a collection of interactive notebooks. 
+Binder is a service that turns a Git repo into a collection of interactive notebooks. 
 When a repository is configured to run as a binder, passing the GitHub repository URL to binder starts the binder-building process.
-binder first builds a docker image that contains all of the software installations specified by a special set of files in the GitHub repository.
+Binder first builds a docker image that contains all of the software installations specified by a special set of files in the GitHub repository.
 A docker image is a set of instructions that are used to create a docker container.
 A docker container is a runnable instance of a docker image -- it's an encapsulated computing environment that can be used to reproducibly install sets of software on diverse computers.
 Armed with the docker container, binder launches an "instance" in the cloud (either on Google Cloud or AWS typically) on which it runs the docker container.
 Binder does some additional work in the background -- if no software configuration files are provided in the GitHub repo, or if those contain a minimal set of software, binder will by default include JupyterHub in the docker.
 When the cloud instance is launched, this is the screen you interact with.
 You interact with the cloud instance  in your browser.
-binders are ephemeral instances -- after a period of inactivity, the instance is automatically shut down, and any work you have done will be lost.
+Binders are ephemeral instances -- after a period of inactivity, the instance is automatically shut down, and any work you have done will be lost.
 You're able to download files from your work before the instance is shut down if you do want to save anything.
 
 
 You may notice that this instance already has a bunch of files on it. 
-And that these files look suspiciously exactly like the files in the GitHub repository [Arcadia-Science/arcadia-computational-training](https://github.com/arcadia-science/arcadia-computational-training).
+And that these files look suspiciously exactly like the files in the GitHub repository <a href="https://github.com/arcadia-science/arcadia-computational-training">Arcadia-Science/arcadia-computational-training</a>. 
 That's because that's the repository we used to build the binder from. 
 </details>
+
+<br />
 
 ## Running commands
 
@@ -299,6 +301,7 @@ ls ../..
 
 ## Credit
 
-This lesson was modified fromL
+This lesson was modified from:
+
 * ANGUS 2019: https://angus.readthedocs.io/en/2019/shell_intro/shell-getting-started-01.html
 * Data Carpentry Genomics: https://datacarpentry.org/shell-genomics/


### PR DESCRIPTION
This PR fixes four formatting issues I just found this morning:

1. I didn't realize that the drop-down html formatting dis-allowed markdown formatting, so I switched the markdown link to an html link
2. I was being silly last friday and merged the PR before accepting @ecpierce's suggestions to capitalize binder
3. the list of urls in the credit section wasn't spaced correctly
4. there was an `L` instead of a `:` for that same list section

Even though this lesson will be taught today, I plan to do it via live coding instead of showing the lesson, so this PR is not urgent.