### PR TITLE
small fix for s5cmd description

### DIFF
--- a/docs/arcadia-users-group/20220919-aws-s3-cli/lesson.md
+++ b/docs/arcadia-users-group/20220919-aws-s3-cli/lesson.md
@@ -310,7 +310,7 @@ tar -xvf s5cmd.tar.gz
 mv s5cmd /usr/local/bin
 ```
 
-After this you should be able to run `s5cmd --version`.
+After this you should be able to run `s5cmd version`. For viewing full functionality run `s5cmd -h`
 
 ### Differences to the official CLI
 


### PR DESCRIPTION
This fixes the description for `s5cmd` - to view the version the command is `s5cmd version` and not `s5cmd --version`, to view the help menu is `s5cmd -h` - at least for `v2.0.0-35bb2fa`