### PR TITLE
Update the home landing page for better descriptions and navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,11 +2,12 @@
 ![](_static/Arcadia_Lockup-XL-K.png)
 
 <br/>
-
 Welcome to the computational training website for Arcadia Science.
-The purpose of this website is to catalogue and host training materials that have been, are being, or will be delivered at Arcadia Science.
+The purpose of this website is to catalogue and host training materials at Arcadia Science.
 We strive to make our training material open and accessible so that it can be useful at time of delivery and for asynchronous learning.
-To discover training materials, navigate to the pages on the top ribbon navigation bar.
+
+The materials on this site include trainings as part of Arcadia Users Group (AUG) and workshops. AUG is a forum to bring data, conceptual problems, or low-level coding questions to discuss in a group setting. We also periodically prepare organized materials to teach in these sessions, which are available on the [Arcadia Users Group](arcadia-users-group/overview.md) page. Additionally, we lead longer [Workshops](workshops/overview.md) on specific topics and skills.
+To discover training materials, navigate to the pages on the left navigation bar.
 
 <br/>
 <br/>


### PR DESCRIPTION
This ended up being a smaller PR and just small changes to the home landing page to better describe where materials are located and the purpose of AUG on the home page instead of just on the AUG landing page. 
Addresses #36 